### PR TITLE
Relyte/remove orphans

### DIFF
--- a/tenderduty_config_updater.sh
+++ b/tenderduty_config_updater.sh
@@ -14,6 +14,7 @@ if [[ $(git status -uno | grep "behind 'origin/main'") ]]; then
     #Restart tenderduty
     cd "$TENDERDUTY_DIR"
     docker-compose down --remove-orphans
+    sleep 5
     docker-compose up -d
 
     #Implement check to see if restart fails

--- a/tenderduty_config_updater.sh
+++ b/tenderduty_config_updater.sh
@@ -13,7 +13,7 @@ if [[ $(git status -uno | grep "behind 'origin/main'") ]]; then
 
     #Restart tenderduty
     cd "$TENDERDUTY_DIR"
-    docker-compose down
+    docker-compose down --remove-orphans
     docker-compose up -d
 
     #Implement check to see if restart fails


### PR DESCRIPTION
Addresses issue #1 . Adds the `--remove-orphans` flag and a short sleep to prevent some docker related errors when new containers attempt to get stood up too fast.